### PR TITLE
Fix and enhance @sane-fmt/wasm32-wasi

### DIFF
--- a/nodejs/wasm32-wasi/bin
+++ b/nodejs/wasm32-wasi/bin
@@ -1,8 +1,12 @@
 #! /usr/bin/env node
+const process = require('process')
+const majorNodeVersion = parseInt(process.versions.node.split('.')[0])
 
 // Initialize WASM BigInt support
-const v8 = require('v8')
-v8.setFlagsFromString('--experimental-wasm-bigint')
+if (majorNodeVersion < 16) {
+  const v8 = require('v8')
+  v8.setFlagsFromString('--experimental-wasm-bigint')
+}
 
 // Call the main program
 require('./dist/main.js')

--- a/nodejs/wasm32-wasi/bin
+++ b/nodejs/wasm32-wasi/bin
@@ -4,8 +4,7 @@ const majorNodeVersion = parseInt(process.versions.node.split('.')[0])
 
 // Initialize WASM BigInt support
 if (majorNodeVersion < 16) {
-  const v8 = require('v8')
-  v8.setFlagsFromString('--experimental-wasm-bigint')
+  require('v8').setFlagsFromString('--experimental-wasm-bigint')
 }
 
 // Call the main program

--- a/nodejs/wasm32-wasi/bin
+++ b/nodejs/wasm32-wasi/bin
@@ -1,16 +1,8 @@
 #! /usr/bin/env node
 
-// The WASM program requires WASM BigInt support, which isn't enabled in Node.js by default.
-// This program will spawn a new Node.js process with WASM BigInt support.
+// Initialize WASM BigInt support
+const v8 = require('v8')
+v8.setFlagsFromString('--experimental-wasm-bigint')
 
-const process = require('process')
-const child_process = require('child_process')
-const main = require.resolve('./dist/main.js')
-const { status } = child_process.spawnSync(process.execPath, [
-  '--experimental-wasm-bigint',
-  main,
-  ...process.argv.slice(2),
-], {
-  stdio: 'inherit',
-})
-process.exit(status)
+// Call the main program
+require('./dist/main.js')

--- a/nodejs/wasm32-wasi/package.json
+++ b/nodejs/wasm32-wasi/package.json
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "typescript": "^4.0.0"
+  },
+  "engines": {
+    "node": ">= 14.0.0"
   }
 }


### PR DESCRIPTION
* Calling `v8.setFlagsFromString` instead of spawning a child process.
* Make it work for Node.js ≥ 16.0.0.