### PR TITLE
Fix the `GITHUB_OUTPUT` feature

### DIFF
--- a/src/app/run.rs
+++ b/src/app/run.rs
@@ -143,7 +143,7 @@ impl App {
         if opt.log_format == LogFormat::GitHubActions {
             if let Some(gh_output_file) = env::var_os("GITHUB_OUTPUT") {
                 let mut gh_output_file = fs::OpenOptions::new()
-                    .write(true)
+                    .append(true)
                     .create(true)
                     .open(&gh_output_file)
                     .unwrap();

--- a/tests/expected-output/github-actions/github-output.txt
+++ b/tests/expected-output/github-actions/github-output.txt
@@ -1,3 +1,4 @@
+EXISTING_VALUE=Something else
 total=11
 changed=5
 unchanged=6

--- a/tests/github_actions.rs
+++ b/tests/github_actions.rs
@@ -4,14 +4,17 @@ pub mod utils;
 pub use utils::*;
 
 use ansi_term::*;
-use std::fs::read_to_string;
+use std::{fs::read_to_string, io::Write};
 
 fn gh_output_file() -> tempfile::NamedTempFile {
-    tempfile::Builder::new()
+    let mut file = tempfile::Builder::new()
         .prefix("github-output")
         .suffix(".txt")
         .tempfile()
-        .expect("create temporary file for GITHUB_OUTPUT")
+        .expect("create temporary file for GITHUB_OUTPUT");
+    writeln!(file, "EXISTING_VALUE=Something else").unwrap();
+    file.flush().unwrap();
+    file
 }
 
 #[test]


### PR DESCRIPTION
`write` which is meant for overwrite was mistakenly used in the previous versions of `sane-fmt`.
Switching to `append` should fix this bug.